### PR TITLE
#19: improve logging of user for c8yclient commands

### DIFF
--- a/cypress/e2e/administration.cy.ts
+++ b/cypress/e2e/administration.cy.ts
@@ -3,7 +3,7 @@ import {
   initRequestStub,
   stubResponses,
 } from "../support/util";
-const { _ } = Cypress;
+const { _, sinon } = Cypress;
 
 declare global {
   interface Window {
@@ -36,6 +36,7 @@ describe("administration", () => {
           headers: { "content-type": "application/json" },
         }),
       ]);
+
       cy.getAuth({ user: "admin", password: "mypassword", tenant: "t12345678" })
         .deleteUser({ userName: "test", displayName: "wewe" })
         .then((response) => {
@@ -64,7 +65,7 @@ describe("administration", () => {
       cy.getAuth({ user: "admin", password: "mypassword", tenant: "t12345678" })
         .deleteUser(
           { userName: "test", displayName: "wewe" },
-          { baseUrl: "https://abc.def.com", failOnStatusCode: true },
+          { baseUrl: "https://abc.def.com", failOnStatusCode: true }
         )
         .then((response) => {
           expect(response.status).to.eq(404);
@@ -79,6 +80,23 @@ describe("administration", () => {
             method: "DELETE",
           });
         });
+    });
+
+    it("throws error for missing user and logs username", (done) => {
+      Cypress.once("fail", (err) => {
+        expect(err.message).to.contain("Missing argument. Requiring IUser");
+        expect(Cypress.log).to.be.calledWithMatch(
+          sinon.match({ message: `{user: test}` })
+        );
+        done();
+      });
+
+      cy.spy(Cypress, "log").log(false);
+
+      //@ts-ignore
+      cy.deleteUser({ user: "test" }).then(() => {
+        throw new Error("Expected error. Should not get here.");
+      });
     });
   });
 
@@ -141,7 +159,7 @@ describe("administration", () => {
     });
 
     it("should use tenant id from env variable", function () {
-      Cypress.env("C8Y_TENANT", "t232447652")
+      Cypress.env("C8Y_TENANT", "t232447652");
       cy.getAuth({ user: "admin", password: "mypassword" })
         .getTenantId()
         .then((id) => {
@@ -151,7 +169,7 @@ describe("administration", () => {
     });
 
     it("should prefer tenant id from auth", function () {
-      Cypress.env("C8Y_TENANT", "t232447652")
+      Cypress.env("C8Y_TENANT", "t232447652");
       cy.getAuth({ user: "admin", password: "mypassword", tenant: "t324678" })
         .getTenantId()
         .then((id) => {

--- a/cypress/e2e/c8yclient.cy.ts
+++ b/cypress/e2e/c8yclient.cy.ts
@@ -289,18 +289,12 @@ describe("c8yclient", () => {
     });
 
     it("fails with error if no auth or cookie is provided", () => {
-      let errorWasThrown = false;
       Cypress.once("fail", (err) => {
         expect(err.message).to.contain("Missing authentication");
-        errorWasThrown = true;
+        expect(window.fetchStub).to.not.have.been.called;
       });
 
-      cy.c8yclient<ICurrentTenant>((client) => client.tenant.current()).then(
-        () => {
-          expect(window.fetchStub).to.not.have.been.called;
-          expect(errorWasThrown).to.be.true;
-        }
-      );
+      cy.c8yclient<ICurrentTenant>((client) => client.tenant.current());
     });
   });
 
@@ -497,7 +491,7 @@ describe("c8yclient", () => {
       Cypress.env("C8Y_TENANT", "t123456789");
     });
 
-    it("should catch and process Cumulocity error response", () => {
+    it("should catch and process Cumulocity error response", (done) => {
       stubResponse(
         new window.Response(JSON.stringify(error), {
           status: 404,
@@ -506,22 +500,23 @@ describe("c8yclient", () => {
         })
       );
 
-      let errorWasThrown = false;
       Cypress.once("fail", (err) => {
         expect(err.message).to.contain("c8yclient failed with");
         expect(err.message).to.contain('"error": "userManagement/Forbidden"');
-        errorWasThrown = true;
+        expect(window.fetchStub).to.have.been.calledOnce;
+        done();
       });
 
       cy.getAuth({ user: "admin", password: "mypassword" })
         .c8yclient<ICurrentTenant>((client) => client.tenant.current())
         .then(() => {
-          expect(window.fetchStub).to.have.been.calledOnce;
-          expect(errorWasThrown).to.be.true;
+          throw new Error(
+            "Expected error. Should not get here."
+          );
         });
     });
 
-    it("should catch and process generic error response", () => {
+    it("should catch and process generic error response", (done) => {
       stubResponse(
         new window.Response("Resource not found!!!", {
           status: 404,
@@ -530,18 +525,19 @@ describe("c8yclient", () => {
         })
       );
 
-      let errorWasThrown = false;
       Cypress.once("fail", (err) => {
         expect(err.message).to.contain("c8yclient failed with");
         expect(err.message).to.contain("Resource not found!!!");
-        errorWasThrown = true;
+        expect(window.fetchStub).to.have.been.calledOnce;
+        done();
       });
 
       cy.getAuth({ user: "admin", password: "mypassword" })
         .c8yclient<ICurrentTenant>((client) => client.tenant.current())
         .then(() => {
-          expect(window.fetchStub).to.have.been.calledOnce;
-          expect(errorWasThrown).to.be.true;
+          throw new Error(
+            "Expected error. Should not get here."
+          );
         });
     });
 
@@ -581,21 +577,21 @@ describe("c8yclient", () => {
         )
       );
 
-      let errorWasThrown = false;
       Cypress.once("fail", (err) => {
         expect(err.message).to.contain("c8yclient failed with: 504");
         expect(err.message).to.contain("Gateway Timeout");
         expect(err.message).to.contain(
           "Error occurred while trying to proxy: localhost:9000/tenant/currentTenant"
         );
-        errorWasThrown = true;
+        expect(window.fetchStub).to.have.been.calledOnce;
       });
 
       cy.getAuth({ user: "admin", password: "mypassword" })
         .c8yclient<ICurrentTenant>((client) => client.tenant.current())
         .then(() => {
-          expect(window.fetchStub).to.have.been.calledOnce;
-          expect(errorWasThrown).to.be.true;
+          throw new Error(
+            "Expected error. Should not get here."
+          );
         });
     });
   });

--- a/cypress/e2e/c8yclient.cy.ts
+++ b/cypress/e2e/c8yclient.cy.ts
@@ -160,9 +160,9 @@ describe("c8yclient", () => {
         "X-XSRF-TOKEN": "fsETfgIBdAnEyOLbADTu22",
       });
 
-      cy.getAuth({ user: "admin", password: "mypassword", tenant: "t1234" })
-        .c8yclient<ICurrentTenant>((client) => client.tenant.current())
-        .then((response) => {
+      cy.useAuth({ user: "admin", password: "mypassword", tenant: "t1234" });
+      cy.c8yclient<ICurrentTenant>((client) => client.tenant.current()).then(
+        (response) => {
           expect(response.status).to.eq(200);
           // Client uses both, Basic and Cookie auth, if available
           expect(_.get(response.requestHeaders, "X-XSRF-TOKEN")).not.to.be
@@ -170,6 +170,23 @@ describe("c8yclient", () => {
           expect(_.get(response.requestHeaders, "Authorization")).to.be
             .undefined;
 
+          expectC8yClientRequest(expectedOptions);
+        }
+      );
+    });
+
+    it("should prefer basic auth over cookie if basic auth is previousSubject", () => {
+      cy.setCookie("XSRF-TOKEN", "fsETfgIBdAnEyOLbADTu22");
+
+      const expectedOptions = _.cloneDeep(requestOptions);
+      _.extend(expectedOptions.headers, {
+        "X-XSRF-TOKEN": "fsETfgIBdAnEyOLbADTu22",
+      });
+
+      cy.getAuth({ user: "admin", password: "mypassword", tenant: "t1234" })
+        .c8yclient<ICurrentTenant>((client) => client.tenant.current())
+        .then((response) => {
+          expect(response.status).to.eq(200);
           expectC8yClientRequest(expectedOptions);
         });
     });
@@ -510,9 +527,7 @@ describe("c8yclient", () => {
       cy.getAuth({ user: "admin", password: "mypassword" })
         .c8yclient<ICurrentTenant>((client) => client.tenant.current())
         .then(() => {
-          throw new Error(
-            "Expected error. Should not get here."
-          );
+          throw new Error("Expected error. Should not get here.");
         });
     });
 
@@ -535,9 +550,7 @@ describe("c8yclient", () => {
       cy.getAuth({ user: "admin", password: "mypassword" })
         .c8yclient<ICurrentTenant>((client) => client.tenant.current())
         .then(() => {
-          throw new Error(
-            "Expected error. Should not get here."
-          );
+          throw new Error("Expected error. Should not get here.");
         });
     });
 
@@ -589,9 +602,7 @@ describe("c8yclient", () => {
       cy.getAuth({ user: "admin", password: "mypassword" })
         .c8yclient<ICurrentTenant>((client) => client.tenant.current())
         .then(() => {
-          throw new Error(
-            "Expected error. Should not get here."
-          );
+          throw new Error("Expected error. Should not get here.");
         });
     });
   });

--- a/cypress/e2e/dates.cy.ts
+++ b/cypress/e2e/dates.cy.ts
@@ -286,13 +286,12 @@ describe("dates", () => {
       });
     });
 
-    it("fails with error for invalid input with throw option", () => {
-      let errorWasThrown = false;
+    it("fails with error for invalid input with throw option", (done) => {
       Cypress.once("fail", (err) => {
         expect(err.message).to.contain(
           "could not be converted into a valid date"
         );
-        errorWasThrown = true;
+        done();
       });
 
       cy.toISODate(
@@ -304,23 +303,22 @@ describe("dates", () => {
         ],
         { invalid: "throw" }
       ).then(() => {
-        expect(errorWasThrown).to.be.true;
+        throw new Error("Expected error. Should not get here.");
       });
     });
 
-    it("throws error on locale id not being registered", () => {
+    it("throws error on locale id not being registered", (done) => {
       // @ts-ignore
       cy.setLanguage("UNSUPPORTED");
-      let errorWasThrown = false;
       Cypress.once("fail", (err) => {
         expect(err.message).to.contain(
           'Missing locale data for the locale "UNSUPPORTED".'
         );
-        errorWasThrown = true;
+        done();
       });
 
       cy.toISODate("15 June 2015 at 9:03:01 +01").then(() => {
-        expect(errorWasThrown).to.be.true;
+        throw new Error("Expected error. Should not get here.");
       });
     });
   });
@@ -338,26 +336,27 @@ describe("dates", () => {
   });
 
   context("dateFormat - failures", () => {
-    let errorWasThrown = false;
     beforeEach(() => {
       cy.setLanguage("en");
+    });
 
-      errorWasThrown = false;
+    it("fails with error for invalid input and throw option enabled", (done) => {
       cy.once("fail", (err) => {
-        errorWasThrown = true;
+        done();
       });
-    });
 
-    it("fails with error for invalid input and throw option enabled", () => {
       cy.dateFormat("3/12/23121", { invalid: "throw" }).then(() => {
-        expect(errorWasThrown).to.be.true;
+        throw new Error("Expected error. Should not get here.");
       });
     });
 
-    it("fails without error for invalid source and ignore option enabled", () => {
+    it("fails without error for invalid source and ignore option enabled", (done) => {
+      cy.once("fail", (err) => {
+        done();
+      });
+
       cy.dateFormat("3/12/23121", { invalid: "ignore" }).then((result) => {
-        expect(result).to.be.undefined;
-        expect(errorWasThrown).to.be.false;
+        throw new Error("Expected error. Should not get here.");
       });
     });
   });
@@ -372,7 +371,7 @@ describe("dates", () => {
       cy.compareDates("30/11/2018, 16:22", isoDate).should("eq", true);
     });
 
-    it ("compares date string iso formatted date string", () => {
+    it("compares date string iso formatted date string", () => {
       cy.compareDates("30/11/2018, 16:22", isoDate.toISOString()).should(
         "eq",
         true
@@ -387,33 +386,33 @@ describe("dates", () => {
         "eq",
         false
       );
-    })
+    });
   });
 
   context("compareDates - failures", () => {
     const isoDate = new Date(Date.UTC(2018, 10, 30, 15, 22, 30, 600));
-    let errorWasThrown = false;
 
     beforeEach(() => {
       cy.setLanguage("en");
 
-      errorWasThrown = false;
-      cy.once("fail", (err) => {
-        errorWasThrown = true;
-      });
     });
 
-    it("fails with error for invalid source and throw option enabled", () => {
+    it("fails with error for invalid source and throw option enabled", (done) => {
+      cy.once("fail", (err) => {
+        done();
+      });
       cy.compareDates("30/11/20181", isoDate, { invalid: "throw" }).then(() => {
-        expect(errorWasThrown).to.be.true;
+        throw new Error("Expected error. Should not get here.");
       });
     });
 
     it("fails without error for invalid source and ignore option enabled", () => {
-      cy.compareDates("30/11/20181", isoDate, { invalid: "ignore" }).then(
+      cy.once("fail", (err) => {
+        throw new Error("Did not expected error. Should not get here.");
+      });
+      cy.compareDates("30/11/201823", isoDate, { invalid: "ignore" }).then(
         (result) => {
           expect(result).to.be.false;
-          expect(errorWasThrown).to.be.false;
         }
       );
     });

--- a/cypress/e2e/general.cy.ts
+++ b/cypress/e2e/general.cy.ts
@@ -18,13 +18,12 @@ describe("general", () => {
         .wait("@interception");
     });
 
-    it("gainsight api.key request will throw exception", () => {
-      let errorWasThrown = false;
+    it("gainsight api.key request will throw exception", (done) => {
       Cypress.on("fail", (err) => {
         expect(err.message).to.eq(
           "Intercepted Gainsight API key call, but Gainsight should have been disabled. Failing..."
         );
-        errorWasThrown = true;
+        done();
       });
 
       cy.disableGainsight()
@@ -34,7 +33,7 @@ describe("general", () => {
         })
         .wait("@interception")
         .then(() => {
-          expect(errorWasThrown).to.be.true;
+          throw new Error("Expected error. Should not get here.");
         });
     });
   });

--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -237,16 +237,14 @@ describe("login", () => {
       }
     );
 
-    it("should throw if no auth options found", () => {
-      let errorWasThrown = false;
+    it("should throw if no auth options found", (done) => {
       Cypress.once("fail", (err) => {
         expect(err.message).to.contain("No valid C8yAuthOptions found");
-        errorWasThrown = true;
+        done();
       });
 
       cy.getAuth().then((result) => {
-        expect(errorWasThrown).to.be.true;
-        expect(result).to.be.undefined;
+        throw new Error("Expected error. Should not get here.");
       });
     });
   });
@@ -280,18 +278,14 @@ describe("login", () => {
       });
     });
 
-    it("should throw if no auth options found", () => {
-      let errorWasThrown = false;
+    it("should throw if no auth options found", (done) => {
       Cypress.once("fail", (err) => {
         expect(err.message).to.contain("No valid C8yAuthOptions found");
-        errorWasThrown = true;
+        done();
       });
 
       cy.useAuth("userthatdoesnotexist").then(() => {
-        expect(errorWasThrown).to.be.true;
-        cy.getAuth().then((auth) => {
-          expect(auth).to.be.undefined;
-        });
+        throw new Error("Expected error. Should not get here.");
       });
     });
   });

--- a/lib/commands/administration.js
+++ b/lib/commands/administration.js
@@ -1,4 +1,4 @@
-import { normalizedArgumentsWithAuth } from "./utils";
+import { normalizedArgumentsWithAuth, throwError } from "./utils";
 const { _ } = Cypress;
 
 Cypress.Commands.add(
@@ -7,9 +7,6 @@ Cypress.Commands.add(
   function (...args) {
     const $args = normalizedArgumentsWithAuth(args);
     const [auth, userOptions, permissions, applications, clientOptions] = $args;
-    if (!userOptions) {
-      throw new Error("Missing argument. Requiring user options argument.");
-    }
 
     const consoleProps = {
       auth,
@@ -22,9 +19,12 @@ Cypress.Commands.add(
     Cypress.log({
       name: "createUser",
       message: userOptions.userName,
-      permissions,
       consoleProps: () => consoleProps,
     });
+
+    if (!userOptions) {
+      throw new Error("Missing argument. Requiring user options argument.");
+    }
 
     // use cy.wrap(auth) to pass auth from createUser to c8yclient
     // note auth might be undefined which means c8yclient will choose auth.
@@ -91,11 +91,8 @@ Cypress.Commands.add(
   function (...args) {
     const $args = normalizedArgumentsWithAuth(args);
     const [auth, user, clientOptions] = $args;
-    if (!user || (_.isObject(user) && !user.userName)) {
-      throw new Error("Missing argument. Requiring IUser object with userName or username argument.");
-    }
 
-    const options =  { ...clientOptions, ...{ failOnStatusCode: false } };
+    const options = { ...clientOptions, ...{ failOnStatusCode: false } };
     const consoleProps = {
       auth: auth,
       clientOptions: options,
@@ -105,6 +102,12 @@ Cypress.Commands.add(
       message: _.isObject(user) ? user.userName : user,
       consoleProps: () => consoleProps,
     });
+
+    if (!user || (_.isObject(user) && !user.userName)) {
+      return throwError(
+        "Missing argument. Requiring IUser object with userName or username argument."
+      );
+    }
 
     return cy
       .wrap(auth, { log: false })
@@ -127,7 +130,8 @@ Cypress.Commands.add(
     const [auth, clientOptions] = $args;
 
     const consoleProps = {
-      clientOptions
+      auth,
+      clientOptions,
     };
     Cypress.log({
       name: "getCurrentTenant",
@@ -151,7 +155,9 @@ Cypress.Commands.add(
     const $args = normalizedArgumentsWithAuth(args);
     const [auth] = $args;
 
-    const consoleProps = {};
+    const consoleProps = {
+      auth,
+    };
     Cypress.log({
       name: "getTenantId",
       consoleProps: () => consoleProps,

--- a/lib/commands/c8yclient.d.ts
+++ b/lib/commands/c8yclient.d.ts
@@ -11,12 +11,17 @@ declare global {
     interface Chainable {
       /**
        * Create a c8y/client `Client` to interact with Cumulocity API. Yielded
-       * results are `Cypress.Response` objects as return by `cy.request`.
+       * results are `Cypress.Response` objects as returned by `cy.request`.
        *
-       * Authentication can be passed via `cy.getAuth` or `cy.useAuth` for basic
-       * auth. If there is a `X-XSRF-TOKEN` cookie, the token will be used for
-       * cookie auth without basic auth. To get the cookie token, call `cy.login`
-       * before using `cy.c8yclient`.
+       * `cy.c8yclient` supports c8y/client `BasicAuth` and `CookieAuth`. To use
+       * any other auth method, such as `BearerAuth`, create a custom `Client` and
+       * pass it in `options`. 
+       * 
+       * Note: If there is a `X-XSRF-TOKEN` cookie, `CookieAuth` will be used as
+       * auth method and basic auth credentials will be ignored. To create the 
+       * cookie token, call `cy.login` before using `cy.c8yclient`. To force using
+       * basic auth method, pass credentials via `cy.getAuth().c8yclient()` or use
+       * `preferBasicAuth` option.
        *
        * `cy.c8yclient` supports chaining of requests. By chaining the response of
        * one request will be provided as second argument to the next request.

--- a/lib/commands/c8yclient.js
+++ b/lib/commands/c8yclient.js
@@ -151,8 +151,9 @@ window.fetch = async function (url, fetchOptions) {
 };
 
 Cypress.Commands.add("c8yclient", { prevSubject: "optional" }, (...args) => {
+  const prevSubjectIsAuth = args && !_.isEmpty(args) && isAuth(args[0]);
   let prevSubject =
-    args && args.length > 0 && !isAuth(args[0]) ? args[0] : undefined;
+    args && !_.isEmpty(args) && !isAuth(args[0]) ? args[0] : undefined;
   let $args = normalizedArgumentsWithAuth(
     args && prevSubject ? args.slice(1) : args
   );
@@ -203,7 +204,9 @@ Cypress.Commands.add("c8yclient", { prevSubject: "optional" }, (...args) => {
   const options = _.defaults(argOptions, defaultOptions);
   // force CookieAuth over BasicAuth if present and not disabled by options
   const auth =
-    cookieAuth && options.preferBasicAuth === false ? cookieAuth : argAuth;
+    cookieAuth && options.preferBasicAuth === false && !prevSubjectIsAuth
+      ? cookieAuth
+      : argAuth;
   const baseUrl = options.baseUrl || Cypress.config().baseUrl;
   const tenant =
     (basicAuth && tenantFromBasicAuth(basicAuth)) ||

--- a/lib/commands/c8yclient.js
+++ b/lib/commands/c8yclient.js
@@ -1,6 +1,7 @@
 import { BasicAuth, Client, CookieAuth, FetchClient } from "@c8y/client";
 import {
   isAuth,
+  getAuthOptionsFromBasicAuthHeader,
   normalizedArgumentsWithAuth,
   restoreClient,
   storeClient,
@@ -29,7 +30,24 @@ window.fetch = async function (url, fetchOptions) {
       message: "",
       consoleProps() {
         const props = {};
+        const cookieAuth =
+          (responseObj.requestHeaders &&
+            responseObj.requestHeaders["X-XSRF-TOKEN"]) ||
+          undefined;
+        const basicAuth =
+          (responseObj.requestHeaders &&
+            responseObj.requestHeaders["Authorization"]) ||
+          undefined;
+
         // props["Options"] = options;
+        if (cookieAuth) {
+          props["CookieAuth"] = `XSRF-TOKEN ${cookieAuth}`;
+        }
+        if (basicAuth) {
+          const auth = getAuthOptionsFromBasicAuthHeader(basicAuth);
+          props["BasicAuth"] = `${basicAuth} (${auth.user})`;
+        }
+
         props["Request"] = {
           responseBody: responseObj.body,
           responseStatus: responseObj.status,
@@ -43,24 +61,26 @@ window.fetch = async function (url, fetchOptions) {
       },
 
       renderProps() {
-        let indicator;
-        let status;
-        if (responseObj && !_.isEmpty(responseObj)) {
-          status = responseObj.status;
-        } else {
-          indicator = "pending";
-          status = "---";
+        function getIndicator() {
+          // returns 'aborted' | 'pending' | 'successful' | 'bad'
+          if (!responseObj) return "pending";
+          if (responseObj.isOkStatusCode) return "successful";
+          return "bad";
         }
 
-        if (!indicator) {
-          indicator = responseObj.isOkStatusCode ? "successful" : "bad";
+        function getStatus() {
+          return (
+            (responseObj && !_.isEmpty(responseObj) && responseObj.status) ||
+            "---"
+          );
         }
 
         return {
-          message: `${fetchOptions.method || "GET"} ${status} ${getDisplayUrl(
-            responseObj.url || ""
-          )}`,
-          indicator,
+          message: `${
+            fetchOptions.method || "GET"
+          } ${getStatus()} ${getDisplayUrl(responseObj.url || "")}`,
+          indicator: getIndicator(),
+          status: getStatus(),
         };
       },
     });

--- a/lib/commands/c8yclient.js
+++ b/lib/commands/c8yclient.js
@@ -41,7 +41,10 @@ window.fetch = async function (url, fetchOptions) {
 
         // props["Options"] = options;
         if (cookieAuth) {
-          props["CookieAuth"] = `XSRF-TOKEN ${cookieAuth}`;
+          const loggedInUser = Cypress.env("C8Y_LOGGED_IN_USER");
+          props["CookieAuth"] = `XSRF-TOKEN ${cookieAuth} ${
+            loggedInUser ? "(" + loggedInUser + ")" : ""
+          }`;
         }
         if (basicAuth) {
           const auth = getAuthOptionsFromBasicAuthHeader(basicAuth);

--- a/lib/commands/login.d.ts
+++ b/lib/commands/login.d.ts
@@ -7,7 +7,7 @@ declare global {
        * Login to Cumulocity.
        *
        * Uses env variables `C8Y_USERNAME` and `C8Y_PASSWORD` if no arguments or no
-       * password is passed.
+       * password is passed. The logged in user will be stored in `C8Y_LOGGED_IN_USER`.
        *
        * Default values for login options:
        * ```

--- a/lib/commands/utils.js
+++ b/lib/commands/utils.js
@@ -147,6 +147,28 @@ function getAuthOptionsFromArgs(...args) {
   return undefined;
 }
 
+export function getAuthOptionsFromBasicAuthHeader(authHeader) {
+  if (
+    !authHeader ||
+    !_.isString(authHeader) ||
+    !authHeader.startsWith("Basic ")
+  ) {
+    return undefined;
+  }
+
+  const base64Credentials = authHeader.slice("Basic ".length);
+  const credentials = Buffer.from(base64Credentials, "base64").toString(
+    "utf-8"
+  );
+
+  const components = credentials.split(":");
+  if (!components || components.length < 2) {
+    return undefined;
+  }
+
+  return { user: components[0], password: components.slice(1).join(":") };
+}
+
 export function persistAuth(auth) {
   const win = cy.state("window");
   if (auth) {


### PR DESCRIPTION
`c8y/client` has some special handling of users that might be confusing when using `cy.c8yclient`. 

Behaviour of `cy.c8yclient` now changed to:
1. prefer basic auth if passed as previousSubject as with `cy.getAuth(...).c8yclient(...)`. this is similar to using `preferBasicAuth` option. 
2. debug logging of `CookieAuth` and `BasicAuth` being used or available to `c8y/client`
3. debug log user for `CookieAuth` and `BasicAuth`

`cy.login` now stores the logged in user as Cypress env `C8Y_LOGGED_IN_USER`.