### PR TITLE
c8yctrl backward support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3116,12 +3116,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4795,9 +4795,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/src/lib/pact/cypresspact.ts
+++ b/src/lib/pact/cypresspact.ts
@@ -21,6 +21,7 @@ import {
   C8yPactRecordingMode,
   C8yPactRecordingModeValues,
   C8yPactModeValues,
+  pactId,
 } from "../../shared/c8ypact";
 import { C8yDefaultPactRunner } from "./runner";
 import { C8yAuthOptions } from "../../shared/auth";
@@ -528,12 +529,27 @@ function recordingMode() {
 }
 
 function getCurrentTestId(): C8yPactID {
-  let key = Cypress.currentTest?.titlePath?.join("__");
-  if (key == null) {
-    key = Cypress.spec?.relative?.split("/").slice(-2).join("__");
-  }
   const pact = Cypress.config().c8ypact;
-  return (pact && pact.id) || key.replace(/ /g, "_");
+  if (pact?.id != null) {
+    const pId = pactId(pact.id);
+    if (pId != null) {
+      return pId;
+    }
+  }
+
+  let key = Cypress.currentTest?.titlePath;
+  if (key == null) {
+    key = Cypress.spec?.relative?.split("/").slice(-2);
+  }
+  const result = pactId(key);
+  if (key == null || result == null) {
+    const error = new Error(
+      "Failed to get or create pact id for current test."
+    );
+    error.name = "C8yPactError";
+    throw error;
+  }
+  return result;
 }
 
 async function savePact(

--- a/src/shared/c8ypact/c8ypact.spec.ts
+++ b/src/shared/c8ypact/c8ypact.spec.ts
@@ -7,9 +7,85 @@ import {
   isPact,
   isPactError,
   isPactRecord,
+  isValidPactId,
+  pactId,
 } from "./c8ypact";
 
 describe("c8ypact", () => {
+  describe("pactId", function () {
+    it("generate id for string", function () {
+      expect(pactId("test")).toBe("test");
+      expect(pactId("test test")).toBe("test_test");
+      expect(pactId("test    test")).toBe("test_test");
+      expect(pactId("test_test")).toBe("test_test");
+      expect(pactId("_test_test_")).toBe("_test_test_");
+    });
+
+    it("remove special characters", function () {
+      expect(pactId("test@#$%^&*()+")).toBe("test");
+      // special handling of _
+      // as value is split to words which are joined by _, there might be multiple _ in a row
+      expect(pactId("test@#$%^&*()_+")).toBe("test__");
+      expect(pactId("test@#$%^&*()_+ test")).toBe("test___test");
+    });
+
+    it("should not split numbers", function () {
+      expect(pactId("c8ypact")).toBe("c8ypact");
+      expect(pactId("c8ypact test")).toBe("c8ypact_test");
+    });
+
+    it("deburrs string", function () {
+      expect(pactId("tést")).toBe("test");
+      expect(pactId("tést tèst")).toBe("test_test");
+    });
+
+    it("trims id string", function () {
+      expect(pactId(" test ")).toBe("test");
+      expect(pactId(" test test ")).toBe("test_test");
+      expect(pactId(["  test  ", "  test"])).toBe("test__test");
+    });
+
+    it("generate id for array of strings", function () {
+      expect(pactId(["test", "test"])).toBe("test__test");
+      expect(pactId(["test", "test test"])).toBe("test__test_test");
+    });
+
+    it("should return undefined for undefined or null", function () {
+      expect(pactId(undefined as any)).toBe(undefined);
+      expect(pactId(null as any)).toBe(null);
+    });
+
+    it("should return undefined for objects", function () {
+      expect(pactId({ test: "test" } as any)).toBe(undefined);
+      expect(pactId({ test: "test", test2: "test" } as any)).toBe(undefined);
+    });
+
+    it("should not change valid ids", function () {
+      expect(pactId("test")).toBe("test");
+      expect(pactId("test_test")).toBe("test_test");
+      expect(pactId("test__test")).toBe("test__test");
+
+      const x = "c8ypact__c8ypact_record_and_load__should_record_c8ypacts";
+      expect(pactId(x)).toBe(x);
+    });
+  });
+
+  describe("isValidPactId", function () {
+    it("valid pact ids", function () {
+      expect(isValidPactId("test")).toBe(true);
+      expect(isValidPactId("test_test")).toBe(true);
+      expect(isValidPactId("test__test")).toBe(true);
+      expect(isValidPactId("test__test2__test_test3_test4")).toBe(true);
+      expect(isValidPactId("test__test_")).toBe(true); // underscore is valid character
+    });
+
+    it("invalid pact ids", function () {
+      expect(isValidPactId("test*#")).toBe(false);
+      expect(isValidPactId("test test")).toBe(false);
+      expect(isValidPactId("tést")).toBe(false);
+    });
+  });
+
   describe("isPactRecord", function () {
     it("isPactRecord validates undefined", function () {
       expect(isPactRecord(undefined)).toBe(false);

--- a/src/shared/c8ypact/c8ypact.ts
+++ b/src/shared/c8ypact/c8ypact.ts
@@ -377,6 +377,7 @@ export class C8yDefaultPactRecord implements C8yPactRecord {
 }
 
 export function isValidPactId(value: string): boolean {
+  if (value == null || value.length > 1000 || !_.isString(value)) return false;
   const validPactIdRegex = /^[a-zA-Z0-9_-]+(__[a-zA-Z0-9_-]+)*$/;
   return validPactIdRegex.test(value);
 }

--- a/test/cypress/e2e/c8ypact.cy.ts
+++ b/test/cypress/e2e/c8ypact.cy.ts
@@ -911,6 +911,34 @@ describe("c8ypact", () => {
     });
   });
 
+  context("c8ypact callback handlers", function () {
+    let startSpy: sinon.SinonSpy;
+
+    before(() => {
+      Cypress.c8ypact.on.suiteStart = () => {
+        cy.log("c8ypact on.suiteStart");
+      };
+      startSpy = cy.spy(Cypress.c8ypact.on, "suiteStart").log(false);
+    });
+
+    context("c8ypact on.suiteStart", function () {
+      before(() => {
+        Cypress.env("MY_SUITE_START", "true");
+      });
+
+      it("should call suiteStart callback", function () {
+        expect(startSpy).to.have.been.calledOnce;
+        expect(startSpy.getCall(0).args).to.have.length(1);
+        expect(startSpy.getCall(0).args[0]).to.deep.eq([
+          "c8ypact",
+          "c8ypact callback handlers",
+          "c8ypact on.suiteStart",
+        ]);
+        expect(Cypress.env("MY_SUITE_START")).to.eq("true");
+      });
+    });
+  });
+
   context("c8ypact matching", function () {
     const response: Cypress.Response<any> = {
       status: 200,

--- a/test/cypress/e2e/c8ypact.cy.ts
+++ b/test/cypress/e2e/c8ypact.cy.ts
@@ -511,19 +511,61 @@ describe("c8ypact", () => {
     it("plugin should be enabled", function () {
       expect(Cypress.env("C8Y_PLUGIN_LOADED")).to.eq("true");
     });
+  });
 
+  context("c8ypact getCurrentTestId", function () {
     it("should create pact identifier from test case name", function () {
       expect(Cypress.c8ypact.getCurrentTestId()).to.equal(
-        "c8ypact__c8ypact_config_and_environment_variables__should_create_pact_identifier_from_test_case_name"
+        "c8ypact__c8ypact_getCurrentTestId__should_create_pact_identifier_from_test_case_name"
       );
     });
+
+    it("should throw error if pact identifier is undefined", function (done) {
+      Cypress.once("fail", (err) => {
+        expect(err.message).to.contain(
+          "Failed to get or create pact id for current test."
+        );
+        done();
+      });
+      cy.stub(Cypress, "currentTest").value({});
+      cy.stub(Cypress.spec, "relative").value(undefined);
+      Cypress.c8ypact.getCurrentTestId();
+    });
+
+    it(
+      "should not throw error if id is annotated",
+      { c8ypact: { id: "mytest" } },
+      function () {
+        cy.stub(Cypress, "currentTest").value({});
+        cy.stub(Cypress.spec, "relative").value(undefined);
+        expect(Cypress.currentTest.titlePath).to.be.undefined;
+        expect(Cypress.spec.relative).to.be.undefined;
+        expect(Cypress.c8ypact.getCurrentTestId()).to.equal("mytest");
+      }
+    );
+
+    it(
+      "should throw error if id is annotated with invalid value",
+      { c8ypact: { id: "&*%+§$%" } },
+      function (done) {
+        Cypress.once("fail", (err) => {
+          expect(err.message).to.contain(
+            "Failed to get or create pact id for current test."
+          );
+          done();
+        });
+        cy.stub(Cypress, "currentTest").value({});
+        cy.stub(Cypress.spec, "relative").value(undefined);
+        Cypress.c8ypact.getCurrentTestId();
+      }
+    );
 
     it(
       "should create pact identifier from test case annotation",
       { c8ypact: { id: "mycustom test case" } },
       function () {
         expect(Cypress.c8ypact.getCurrentTestId()).to.equal(
-          "mycustom test case"
+          "mycustom_test_case"
         );
       }
     );


### PR DESCRIPTION
Very basic integration with upcoming `c8yctrl`. 
- added `pactId()`
- added `Cypress.c8ypact.on.suiteStart` as a hook for calling `c8yctrl`