### PR TITLE
Support shell and system version in requires annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Administration related commands
 - `getCurrentTenant` and `getTenantId`
 - `createUser` and `deleteUser`
 - `assignUserRoles` and `clearUserRoles`
-- `getSystemVersion`
+- `getSystemVersion` and `getShellVersion`
 
 Component testing
 - `mount`
@@ -70,6 +70,7 @@ Component testing
 - `c8yclient`, `c8yclientf`
 - `c8ymatch`
 - `retryRequest`
+- `request`
 
 See [Integration and API testing](./doc/API%20and%20Integration%20Testing.md) for more information.
 
@@ -78,7 +79,7 @@ See [Integration and API testing](./doc/API%20and%20Integration%20Testing.md) fo
 Add dependency to your package.json and install via npm or yarn.
 
 ```bash
-npm install cumulocity-cypress --save-dev
+npm install cumulocity-cypress ---dev
 ```
 or 
 

--- a/src/lib/commands/administration.ts
+++ b/src/lib/commands/administration.ts
@@ -1,4 +1,5 @@
 import {
+  getShellVersionFromEnv,
   getSystemVersionFromEnv,
   normalizedC8yclientArguments,
   throwError,
@@ -672,7 +673,7 @@ Cypress.Commands.add(
       consoleProps: () => consoleProps,
     });
 
-    const version = Cypress.env("C8Y_SHELL_VERSION");
+    const version = getShellVersionFromEnv();
     if (version) {
       consoleProps.Yields = version;
       return cy.wrap<string | undefined>(version);
@@ -689,6 +690,9 @@ Cypress.Commands.add(
         const shellVersion = toSemverVersion(response?.body?.version);
         consoleProps.Yields = version || null;
         Cypress.env("C8Y_SHELL_VERSION", shellVersion);
+        if (shellVersion != null && !Cypress.env("C8Y_SHELL_NAME")) {
+          Cypress.env("C8Y_SHELL_NAME", myShell);
+        }
         cy.wrap<string | undefined>(shellVersion);
       });
   }

--- a/src/lib/commands/requires.ts
+++ b/src/lib/commands/requires.ts
@@ -6,6 +6,8 @@ import {
 import * as semver from "semver";
 import { getSystemVersionFromEnv } from "../utils";
 
+const { _ } = Cypress;
+
 interface C8yRequire {
   /**
    * System versions required to run the test. System version is taken from C8Y_SYSTEM_VERSION
@@ -52,12 +54,33 @@ beforeEach(function () {
 });
 
 /**
- * Checks if `C8Y_SYSTEM_VERSION` or `C8Y_VERSION` satisfy the requirements of the current test.
+ * Checks if `Cypress.config().requires` matches environment for the current test.
  * @returns `true` if the system version satisfies the requirements of the current test, `false` otherwise.
  */
 export function isSystemVersionSatisfyingCurrentTestRequirements(): boolean {
-  return isVersionSatisfyingRequirements(
-    getSystemVersionFromEnv(),
-    Cypress.config().requires
-  );
+  const requires = Cypress.config().requires;
+  if (requires == null) return true;
+
+  if (_.isArrayLike(requires)) {
+    return isVersionSatisfyingRequirements(
+      getSystemVersionFromEnv(),
+      requires as string[]
+    );
+  } else {
+    let systemResult = true;
+    if (requires.system != null) {
+      systemResult = isVersionSatisfyingRequirements(
+        getSystemVersionFromEnv(),
+        requires.system
+      );
+    }
+    let shellResult = true;
+    if (requires.shell != null) {
+      shellResult = isVersionSatisfyingRequirements(
+        Cypress.env("C8Y_SHELL_VERSION"),
+        requires.shell
+      );
+    }
+    return systemResult && shellResult;
+  }
 }

--- a/src/lib/commands/requires.ts
+++ b/src/lib/commands/requires.ts
@@ -4,7 +4,7 @@ import {
 } from "cumulocity-cypress";
 
 import * as semver from "semver";
-import { getSystemVersionFromEnv } from "../utils";
+import { getShellVersionFromEnv, getSystemVersionFromEnv } from "../utils";
 
 const { _ } = Cypress;
 
@@ -77,7 +77,7 @@ export function isSystemVersionSatisfyingCurrentTestRequirements(): boolean {
     let shellResult = true;
     if (requires.shell != null) {
       shellResult = isVersionSatisfyingRequirements(
-        Cypress.env("C8Y_SHELL_VERSION"),
+        getShellVersionFromEnv(),
         requires.shell
       );
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -284,6 +284,10 @@ export function getSystemVersionFromEnv(): string | undefined {
   return result;
 }
 
+export function getShellVersionFromEnv(): string | undefined {
+  return Cypress.env(`C8Y_SHELL_VERSION`);
+}
+
 export function getBaseUrlFromEnv(): string | undefined {
   return (
     Cypress.env(`C8Y_BASEURL`) ||

--- a/src/shared/c8ypact/c8ypact.ts
+++ b/src/shared/c8ypact/c8ypact.ts
@@ -193,7 +193,13 @@ export interface C8yPactInfo extends C8yPactConfigOptions {
   /**
    * Version information of the system, runner and pact standard used to record the pact.
    */
-  version?: { system?: string; c8ypact?: string; runner?: string };
+  version?: {
+    system?: string;
+    shell?: string;
+    shellName?: string;
+    c8ypact?: string;
+    runner?: string;
+  };
   /**
    * Title of the pact. Title is an array of suite and test titles.
    */

--- a/src/shared/versioning.ts
+++ b/src/shared/versioning.ts
@@ -4,11 +4,19 @@ import lodash1 from "lodash";
 import * as lodash2 from "lodash";
 const _ = lodash1 || lodash2;
 
+export type RequireConfigKeys = "shell" | "system";
+export type RequireConfigVersions = (string | null)[];
+
 /**
  * A configuration option for required versions. It is an array of semver ranges or `null` to allow
  * version without specifying a range.
  */
-export type C8yRequireConfigOption = (string | null)[];
+export type C8yRequireConfigOption =
+  | RequireConfigVersions
+  | {
+      shell?: RequireConfigVersions;
+      system?: RequireConfigVersions;
+    };
 
 /**
  * Checks if the given version satisfies the requirements provided as an array of semver ranges.
@@ -19,7 +27,7 @@ export type C8yRequireConfigOption = (string | null)[];
  */
 export function isVersionSatisfyingRequirements(
   version?: string | semver.SemVer,
-  requires?: C8yRequireConfigOption
+  requires?: RequireConfigVersions
 ): boolean {
   if (!requires || !_.isArrayLike(requires) || _.isEmpty(requires)) return true;
   if (requires.length === 1 && _.first(requires) == null) return true;
@@ -44,7 +52,7 @@ export function isVersionSatisfyingRequirements(
  */
 export function getRangesSatisfyingVersion(
   version: semver.SemVer | string,
-  requires?: (string | null)[]
+  requires?: RequireConfigVersions
 ): string[] {
   if (version == null || requires == null || _.isEmpty(requires)) {
     return [];
@@ -63,7 +71,7 @@ export function getRangesSatisfyingVersion(
  */
 export function getMinSatisfyingVersion(
   version: string | semver.SemVer,
-  ranges: (string | null)[]
+  ranges: RequireConfigVersions
 ): semver.SemVer | undefined {
   const minVersions = getMinSatisfyingVersions(version, ranges);
   return _.first(minVersions);
@@ -77,7 +85,7 @@ export function getMinSatisfyingVersion(
  */
 export function getMinSatisfyingVersions(
   version: string | semver.SemVer,
-  ranges: (string | null)[]
+  ranges: RequireConfigVersions
 ): semver.SemVer[] {
   if (!version || !ranges || !_.isString(version) || !_.isArray(ranges)) {
     return [];

--- a/test/cypress/e2e/administration.cy.ts
+++ b/test/cypress/e2e/administration.cy.ts
@@ -23,6 +23,7 @@ describe("administration", () => {
     Cypress.env("C8Y_VERSION", undefined);
     Cypress.env("C8Y_SYSTEM_VERSION", undefined);
     Cypress.env("C8Y_SHELL_VERSION", undefined);
+    Cypress.env("C8Y_SHELL_NAME", undefined);
 
     Cypress.c8ypact.current = null;
 
@@ -677,7 +678,7 @@ describe("administration", () => {
     });
 
     it("should use C8Y_SHELL_NAME env variable", function () {
-      stubEnv({ C8Y_SHELL_NAME: "cockpit" });
+      stubEnv({ C8Y_SHELL_NAME: "cockpit2" });
       stubResponses([
         new window.Response(
           JSON.stringify({
@@ -697,8 +698,10 @@ describe("administration", () => {
         .then((version) => {
           expect(version).to.equal("10.2.11");
           expect(window.fetchStub.callCount).to.equal(1);
+          expect(Cypress.env("C8Y_SHELL_VERSION")).to.equal("10.2.11");
+          expect(Cypress.env("C8Y_SHELL_NAME")).to.equal("cockpit2");
           expectC8yClientRequest({
-            url: `${Cypress.config().baseUrl}/apps/cockpit/cumulocity.json`,
+            url: `${Cypress.config().baseUrl}/apps/cockpit2/cumulocity.json`,
             auth,
           });
         });
@@ -728,6 +731,7 @@ describe("administration", () => {
             auth,
           });
           expect(Cypress.env("C8Y_SHELL_VERSION")).to.equal("10.1.11");
+          expect(Cypress.env("C8Y_SHELL_NAME")).to.equal("mycockpit");
         });
     });
   });

--- a/test/cypress/e2e/c8ypact.cy.ts
+++ b/test/cypress/e2e/c8ypact.cy.ts
@@ -580,27 +580,51 @@ describe("c8ypact", () => {
     );
 
     it(
-      "should add min version to pact id",
+      "should add min system version to pact id",
       { requires: ["1.2.x"] },
       function () {
         stubEnv({ C8Y_SYSTEM_VERSION: "1.2.3" });
         expect(Cypress.c8ypact.getCurrentTestId()).to.eq(
-          "1_2__c8ypact__c8ypact_getCurrentTestId__should_add_min_version_to_pact_id"
+          "1_2__c8ypact__c8ypact_getCurrentTestId__should_add_min_system_version_to_pact_id"
         );
       }
     );
 
     it(
-      "should add min version to pact id using c8ypact id",
-      { requires: ["1.2.x"], c8ypact: { id: "my_pact" } },
+      "should add min shell version to pact id",
+      { requires: { shell: ["1.2.x"] } },
+      function () {
+        stubEnv({ C8Y_SHELL_VERSION: "1.2.3" });
+        expect(Cypress.c8ypact.getCurrentTestId()).to.eq(
+          "1_2__c8ypact__c8ypact_getCurrentTestId__should_add_min_shell_version_to_pact_id"
+        );
+      }
+    );
+
+    it(
+      "should add min system version to pact id using c8ypact id",
+      { requires: { system: ["1.2.x"] }, c8ypact: { id: "my_pact" } },
       function () {
         stubEnv({ C8Y_SYSTEM_VERSION: "1.2.3" });
         expect(Cypress.c8ypact.getCurrentTestId()).to.eq("1_2__my_pact");
       }
     );
 
+    it(
+      "should add min shell version to pact id using c8ypact id",
+      { requires: { shell: ["1.2.x"] }, c8ypact: { id: "my_pact" } },
+      function () {
+        stubEnv({ C8Y_SHELL_VERSION: "1.2.3" });
+        expect(Cypress.c8ypact.getCurrentTestId()).to.eq("1_2__my_pact");
+      }
+    );
+
     it("should not add version if no system version is set", function () {
-      stubEnv({ C8Y_SYSTEM_VERSION: undefined, C8Y_VERSION: undefined });
+      stubEnv({
+        C8Y_SYSTEM_VERSION: undefined,
+        C8Y_VERSION: undefined,
+        C8Y_SHELL_VERSION: undefined,
+      });
       expect(Cypress.c8ypact.getCurrentTestId()).to.eq(
         "c8ypact__c8ypact_getCurrentTestId__should_not_add_version_if_no_system_version_is_set"
       );
@@ -621,11 +645,29 @@ describe("c8ypact", () => {
     });
 
     it(
+      "should use C8Y_SHELL_VERSION if set",
+      { requires: { shell: ["1.2.3"] } },
+      function () {
+        stubEnv({ C8Y_SYSTEM_VERSION: undefined, C8Y_SHELL_VERSION: "1.2.3" });
+        expect(Cypress.c8ypact.getCurrentTestId()).to.contain("1_2_3__");
+      }
+    );
+
+    it(
       "should prefer C8Y_SYSTEM_VERSION over C8Y_VERSION",
       { requires: [">=2", "^1.2.3"] },
       function () {
         stubEnv({ C8Y_SYSTEM_VERSION: "1.2.5", C8Y_VERSION: "2.0.0" });
         expect(Cypress.c8ypact.getCurrentTestId()).to.contain("1_2_3__");
+      }
+    );
+
+    it(
+      "should prefer shell version over system version",
+      { requires: { shell: [">1"], system: [">1"] } },
+      function () {
+        stubEnv({ C8Y_SYSTEM_VERSION: "1.2.5", C8Y_SHELL_VERSION: "2.0.0" });
+        expect(Cypress.c8ypact.getCurrentTestId()).to.contain("2__");
       }
     );
 
@@ -647,6 +689,17 @@ describe("c8ypact", () => {
         stubEnv({ C8Y_SYSTEM_VERSION: "1.2.5" });
         expect(Cypress.c8ypact.getCurrentTestId()).to.eq(
           "c8ypact__c8ypact_getCurrentTestId__should_not_add_system_version_if_range_only_has_null_value"
+        );
+      }
+    );
+
+    it(
+      "should not add system or shell version if ranges only have null value",
+      { requires: { shell: [null], system: [null] } },
+      function () {
+        stubEnv({ C8Y_SYSTEM_VERSION: "1.2.5", C8Y_SHELL_VERSION: "2.0.0" });
+        expect(Cypress.c8ypact.getCurrentTestId()).to.eq(
+          "c8ypact__c8ypact_getCurrentTestId__should_not_add_system_or_shell_version_if_ranges_only_have_null_value"
         );
       }
     );

--- a/test/cypress/e2e/requires.cy.ts
+++ b/test/cypress/e2e/requires.cy.ts
@@ -23,14 +23,16 @@ describe("c8ypact versions", function () {
   context("isSystemVersionSatisfyingCurrentTestRequirements", function () {
     before(() => {
       Cypress.env("C8Y_SYSTEM_VERSION", "1.2.3");
+      Cypress.env("C8Y_SHELL_VERSION", "2.5.0");
     });
 
     after(() => {
       Cypress.env("C8Y_SYSTEM_VERSION", undefined);
+      Cypress.env("C8Y_SHELL_VERSION", undefined);
     });
 
     it(
-      "should return true if version is satisfied",
+      "should return true if system version is satisfied",
       { requires: ["1.2"] },
       function () {
         expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.true;
@@ -38,7 +40,39 @@ describe("c8ypact versions", function () {
     );
 
     it(
-      "should return true if version is satisfied with multiple ranges",
+      "should return true if system version is satisfied specified as object",
+      { requires: { system: ["1.2"] } },
+      function () {
+        expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.true;
+      }
+    );
+
+    it(
+      "should return true if shell version is satisfied",
+      { requires: { shell: ["2"] } },
+      function () {
+        expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.true;
+      }
+    );
+
+    it(
+      "should return true if shell and system version are satisfied",
+      { requires: { shell: ["2"], system: ["1.2"] } },
+      function () {
+        expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.true;
+      }
+    );
+
+    it(
+      "should return false if one of shell and system versions are not satisfied",
+      { requires: { shell: ["2.6"], system: ["1.2"] } },
+      function () {
+        expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.false;
+      }
+    );
+
+    it(
+      "should return true if system version is satisfied with multiple ranges",
       { requires: ["2.3.4", "1"] },
       function () {
         expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.true;
@@ -46,8 +80,24 @@ describe("c8ypact versions", function () {
     );
 
     it(
-      "should return false if version is not satisfied",
+      "should return true if shell version is satisfied with multiple ranges",
+      { requires: { shell: ["1.3.4", "2.5"] } },
+      function () {
+        expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.true;
+      }
+    );
+
+    it(
+      "should return false if system version is not satisfied",
       { requires: ["1.3"] },
+      function () {
+        expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.false;
+      }
+    );
+
+    it(
+      "should return false if shell version is not satisfied",
+      { requires: ["3.0"] },
       function () {
         expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.false;
       }
@@ -56,6 +106,14 @@ describe("c8ypact versions", function () {
     it(
       "should return true if no version is required",
       { requires: [] },
+      function () {
+        expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.true;
+      }
+    );
+
+    it(
+      "should return true if no version is required with empty object",
+      { requires: {} },
       function () {
         expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.true;
       }
@@ -71,10 +129,28 @@ describe("c8ypact versions", function () {
     );
 
     it(
+      "should return false if no shell version is set",
+      { requires: ["2.5"] },
+      function () {
+        stubEnv({ C8Y_SHELL_VERSION: undefined });
+        expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.false;
+      }
+    );
+
+    it(
       "should return true if no system version is set and null is defined in required versions",
       { requires: ["1.3", null] },
       function () {
         stubEnv({ C8Y_SYSTEM_VERSION: undefined });
+        expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.true;
+      }
+    );
+
+    it(
+      "should return true if no shell version is set and null is defined in required versions",
+      { requires: { shell: ["2.5", null] } },
+      function () {
+        stubEnv({ C8Y_SHELL_VERSION: undefined });
         expect(isSystemVersionSatisfyingCurrentTestRequirements()).to.be.true;
       }
     );


### PR DESCRIPTION
Add new custom command `cy.getShellVersion()`
Provide shell application using `C8Y_SHELL_NAME`.
Support shell and system version in requires annotation.