### PR TITLE
fix(commands): Fix "cumulocity-cypress" import for commands

### DIFF
--- a/src/contrib/ajv.ts
+++ b/src/contrib/ajv.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 import Ajv, { AnySchemaObject, SchemaObject } from "ajv";
 import addFormats from "ajv-formats";
 
-import { C8ySchemaMatcher } from "cumulocity-cypress";
+import { C8ySchemaMatcher } from "cumulocity-cypress/shared/c8ypact/schema";
 
 import draft06Schema from "ajv/lib/refs/json-schema-draft-06.json";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ export * from "./lib/pact/runner";
 export * from "./lib/pact/fetchclient";
 export * from "./lib/pact/cypresspact";
 export * from "./shared/auth";
-export * from "./shared/c8ypact/fileadapter";
 export * from "./shared/versioning";
 export { registerDefaultLocales, registerLocale } from "./lib/locale/locale";
 export {

--- a/src/lib/commands/requires.ts
+++ b/src/lib/commands/requires.ts
@@ -1,7 +1,7 @@
 import {
   C8yRequireConfigOption,
   isVersionSatisfyingRequirements,
-} from "cumulocity-cypress";
+} from "cumulocity-cypress/shared/versioning";
 
 import * as semver from "semver";
 import { getShellVersionFromEnv, getSystemVersionFromEnv } from "../utils";


### PR DESCRIPTION
The `> Cannot find module 'fs'` error for component and e2e tests has been fixed. 

Closes #150 
