### PR TITLE
fix(commands): Fixed cy.getTenantId with authorization cookies in env

### DIFF
--- a/src/lib/commands/administration.ts
+++ b/src/lib/commands/administration.ts
@@ -567,7 +567,7 @@ Cypress.Commands.add("getTenantId", { prevSubject: "optional" }, (...args) => {
     consoleProps: () => consoleProps,
   });
 
-  if (Cypress.env("C8Y_TENANT") && !auth.tenant) {
+  if (Cypress.env("C8Y_TENANT") && !auth?.tenant) {
     consoleProps.C8Y_TENANT = Cypress.env("C8Y_TENANT");
     return cy.wrap<string>(Cypress.env("C8Y_TENANT"));
   }

--- a/test/cypress/e2e/administration.cy.ts
+++ b/test/cypress/e2e/administration.cy.ts
@@ -591,6 +591,17 @@ describe("administration", () => {
         });
     });
 
+    it("should not fail for CookieAuth", function () {
+      cy.setCookie("XSRF-TOKEN", "123");
+      cy.setCookie("authorization", "213412")
+
+      stubEnv({ C8Y_USERNAME: "admin", C8Y_PASSWORD: "mypassword", C8Y_TENANT: "t1234"});
+      cy.getTenantId().then((id) => {
+        expect(id).to.eq("t1234");
+        expect(window.fetchStub.callCount).to.equal(0);
+      });
+    });
+
     it("should use tenant id from pact recording when mocking", function () {
       stubEnv({ C8Y_PACT_MODE: "mock", C8Y_PLUGIN_LOADED: "true" });
       Cypress.c8ypact.current = new C8yDefaultPact(


### PR DESCRIPTION
`cy.getTenantId()` threw an error after `cy.login()` set authorization cookies in the environment. 

Closes #153 