### PR TITLE
feat(c8yctrl): Allow proxy configuration of proxy options in c8yctrl.config.ts

### DIFF
--- a/src/c8yctrl/c8yctrl-dev.config.ts
+++ b/src/c8yctrl/c8yctrl-dev.config.ts
@@ -7,6 +7,26 @@ import {
 import { Request } from "express";
 
 export default (config: C8yPactHttpControllerConfig) => {
+  // Example: Custom proxy options to reroute certain requests
+  // config.proxyOptions = {
+  //   router: (req) => {
+  //     if (req.url && req.url.startsWith("/service/dtm/")) {
+  //       config.logger?.warn(`Rerouting ${req.url} to localhost:8081`);
+  //       return "http://localhost:8081";
+  //     }
+  //     return config.baseUrl;
+  //   },
+
+  //   // Optional: Remove the /service/dtm prefix when forwarding
+  //   pathRewrite: (path) => {
+  //     if (path.startsWith("/service/dtm/")) {
+  //       config.logger?.warn(`Rewriting path ${path} to remove /service/dtm prefix`);
+  //       return path.replace(/^\/service\/dtm/, "/");
+  //     }
+  //     return path;
+  //   },
+  // };
+
   /**
    * onProxyResponse is used to filter out requests that are already recorded. This is to avoid
    * recording the same request multiple times.
@@ -27,4 +47,6 @@ export default (config: C8yPactHttpControllerConfig) => {
     }
     return record == null;
   };
+
+  return config;
 };

--- a/src/shared/c8yctrl/httpcontroller-options.ts
+++ b/src/shared/c8yctrl/httpcontroller-options.ts
@@ -19,6 +19,8 @@ import winston from "winston";
 import { C8yAuthOptions } from "../auth";
 import { C8yBaseUrl, C8yTenant } from "../types";
 
+import { Options as HttpProxyMiddlewareOptions } from "http-proxy-middleware";
+
 type LogFormat =
   | "json"
   | "simple"
@@ -163,6 +165,10 @@ export interface C8yPactHttpControllerOptions {
    * Callbacks for hooking into the controller lifecycle.
    */
   on: C8yPactHttpControllerCallbackOptions;
+  /**
+   * Options to pass to the underlying http-proxy.
+   */
+  proxyOptions?: Omit<HttpProxyMiddlewareOptions, "on" | "plugins" | "ejectPlugins">;
 }
 
 export interface C8yPactHttpControllerCallbackOptions {


### PR DESCRIPTION
Example usage for running custom microservice requests against a local port 8081 and removing the service path for local use:

```
config.proxyOptions = {
  router: (req) => {
    if (req.url && req.url.startsWith("/service/custom-ms/")) {
      config.logger?.warn(`Rerouting ${req.url} to localhost:8081`);
      return "http://localhost:8081";
    }
    return config.baseUrl;
  },

  pathRewrite: (path) => {
    if (path.startsWith("/service/custom-ms/")) {
      config.logger?.warn(`Rewriting path ${path} to remove /service/custom-ms prefix`);
      return path.replace(/^\/service\/custom-ms/, "/");
    }
    return path;
  },
};
```