### PR TITLE
feat: Pact runner assertions. Fail on max duration.

### DIFF
--- a/src/lib/pact/runner.ts
+++ b/src/lib/pact/runner.ts
@@ -52,7 +52,7 @@ export interface C8yPactRunnerOptions {
    * Assertions for the runner. If one of the assertions fail on request execution,
    * the test will fail.
    */
-  assertions?: C8yPactRunnerAssertions
+  assertions?: C8yPactRunnerAssertions;
 }
 
 export interface C8yPactRunnerAssertions {


### PR DESCRIPTION
`C8yPactRunner` and `Cypress.c8ypact.pactRunner` do now allow configuring assertions (quality gates) when running tests from `C8yPact` documents. The `maxRequestDuration` assertion allows to fail tests if measured duration of one of the requests exceeds the configured number. All failing requests will be listed in the error message.

```typescript
it('run pact objects', { c8ypact: { id: 'my-test-pact' } }, function () {
  Cypress.c8ypact.pactRunner?.runTest(Cypress.c8ypact.current, {
    assertions: { maxRequestDuration: 50 }
  });
});
```