### PR TITLE
feat: Enable recording and matching of multiple tests in same pact

### DIFF
--- a/src/lib/pact/cypresspact.ts
+++ b/src/lib/pact/cypresspact.ts
@@ -407,47 +407,52 @@ if (_.get(Cypress, "__c8ypact.initialized") === undefined) {
       return;
     }
 
-    if (isRecordingEnabled() && recordingMode() === "refresh") {
-      cy.task(
-        "c8ypact:remove",
-        Cypress.c8ypact.getCurrentTestId(),
-        debugLogger()
-      );
-    }
+    if (
+      Cypress.c8ypact.current == null ||
+      Cypress.c8ypact.current?.id !== Cypress.c8ypact.getCurrentTestId()
+    ) {
+      if (isRecordingEnabled() && recordingMode() === "refresh") {
+        cy.task(
+          "c8ypact:remove",
+          Cypress.c8ypact.getCurrentTestId(),
+          debugLogger()
+        );
+      }
 
-    Cypress.c8ypact.loadCurrent().then((pact) => {
-      if (pact?.id === Cypress.c8ypact.current?.id) {
-        // already loaded, do not override current pact
+      Cypress.c8ypact.loadCurrent().then((pact) => {
+        if (pact?.id === Cypress.c8ypact.current?.id) {
+          // already loaded, do not override current pact
+          logger?.end();
+          return;
+        }
+        Cypress.c8ypact.current = pact ?? null;
+        consoleProps.current = pact ?? null;
+
+        // set tenant and baseUrl from pact info if not configured
+        // this is needed to not require tenant and baseUrl for fully mocked tests
+        if (!Cypress.env("C8Y_TENANT") && pact?.info?.tenant) {
+          Cypress.env("C8Y_TENANT", pact?.info?.tenant);
+        }
+
+        const baseUrl = getBaseUrlFromEnv();
+        const pactBaseUrl = pact?.info?.baseUrl;
+        if (
+          baseUrl == null ||
+          (pactBaseUrl != null &&
+            baseUrl === Cypress.config().baseUrl &&
+            Cypress.c8ypact.config.strictMocking === true)
+        ) {
+          Cypress.env("C8Y_BASEURL", pactBaseUrl);
+          consoleProps.baseUrl = getBaseUrlFromEnv();
+        }
+
+        if (pact != null && _.isFunction(Cypress.c8ypact.on.loadPact)) {
+          Cypress.c8ypact.on.loadPact(pact);
+        }
+
         logger?.end();
-        return;
-      }
-      Cypress.c8ypact.current = pact ?? null;
-      consoleProps.current = pact ?? null;
-
-      // set tenant and baseUrl from pact info if not configured
-      // this is needed to not require tenant and baseUrl for fully mocked tests
-      if (!Cypress.env("C8Y_TENANT") && pact?.info?.tenant) {
-        Cypress.env("C8Y_TENANT", pact?.info?.tenant);
-      }
-
-      const baseUrl = getBaseUrlFromEnv();
-      const pactBaseUrl = pact?.info?.baseUrl;
-      if (
-        baseUrl == null ||
-        (pactBaseUrl != null &&
-          baseUrl === Cypress.config().baseUrl &&
-          Cypress.c8ypact.config.strictMocking === true)
-      ) {
-        Cypress.env("C8Y_BASEURL", pactBaseUrl);
-        consoleProps.baseUrl = getBaseUrlFromEnv();
-      }
-
-      if (pact != null && _.isFunction(Cypress.c8ypact.on.loadPact)) {
-        Cypress.c8ypact.on.loadPact(pact);
-      }
-
-      logger?.end();
-    });
+      });
+    }
   });
 }
 


### PR DESCRIPTION
Multiple tests can now be recorded and matched into the same pact file without resetting the pact before each of the tests. If the pact id of the test equals the pact id of `Cypress.c8ypact.current`, the pact is not reloaded for the test. and matching as well as recording will continue without any resetting in between the tests. 

```typescript
context("my tests", { c8ypact: { id: `agent-roundtrip-read` }  },  () => {
  it("test case 1", () => {
    // ...
  }); 
  it("test case 2", () => {
    // ...
  }); 
});
