### PR TITLE
feat: Allow configuring tenant for user aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,33 @@ Cypress.env("admin_username", "admin");
 Cypress.env("admin_password", "password");
 ```
 
+#### Tenant-per-user-alias configuration
+
+User aliases can also be configured with different tenants using the `${userAlias}_tenant` environment variable. This is useful for testing multi-tenant scenarios, such as parent/child tenant relationships, where different users may need to authenticate against different tenants.
+
+```typescript
+// Configure first user with tenant1
+Cypress.env("user1_username", "user1");
+Cypress.env("user1_password", "password1");
+Cypress.env("user1_tenant", "tenant1");
+
+// Configure second user with tenant2
+Cypress.env("user2_username", "user2");
+Cypress.env("user2_password", "password2");
+Cypress.env("user2_tenant", "tenant2");
+
+// Use in tests
+cy.getAuth("user1").c8yclient(...); // Uses tenant1
+cy.getAuth("user2").c8yclient(...); // Uses tenant2
+```
+
+The tenant resolution follows this priority order:
+1. Explicit `tenant` property in auth options (highest priority)
+2. `${userAlias}_tenant` environment variable (if user alias is used)
+3. `C8Y_TENANT` environment variable (fallback, lowest priority)
+
+This enables implementing multi-tenant test scenarios where you can test interactions between parent and child tenants in a single test.
+
 When using user aliases, token authentication takes precedence over username/password if both are configured.
 
 #### Using authentication tokens

--- a/src/c8yscrn/startup.ts
+++ b/src/c8yscrn/startup.ts
@@ -68,6 +68,7 @@ const logEnv = debug("c8y:scrn:env");
           key.startsWith("C8Y_") ||
           key.endsWith("_username") ||
           key.endsWith("_password") ||
+          key.endsWith("_tenant") ||
           key.endsWith("_token")
       ),
     };

--- a/src/lib/commands/auth.ts
+++ b/src/lib/commands/auth.ts
@@ -90,10 +90,12 @@ const getAuthEnvVariables = () => {
       key.endsWith("_username") ||
       key.endsWith("_password") ||
       key.endsWith("_token") ||
+      key.endsWith("_tenant") ||
       key === "C8Y_USERNAME" ||
       key === "C8Y_USER" ||
       key === "C8Y_PASSWORD" ||
       key === "C8Y_TOKEN" ||
+      key === "C8Y_TENANT" ||
       key === "C8Y_XSRF_TOKEN" ||
       key === "C8Y_AUTHORIZATION"
     ) {

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -196,7 +196,10 @@ export function authWithTenant(env: any, options: C8yAuthOptions) {
     return options;
   }
 
-  const tenant = env[`C8Y_TENANT`];
+  let tenant = env[`C8Y_TENANT`];
+  if (options.userAlias != null) {
+    tenant = env[`${options.userAlias}_tenant`] || tenant;
+  }
   if (tenant && !options?.tenant) {
     _.extend(options, { tenant });
   }

--- a/test/cypress/e2e/auth.cy.ts
+++ b/test/cypress/e2e/auth.cy.ts
@@ -217,6 +217,7 @@ describe("auth", () => {
         C8Y_USERNAME: "myusername",
         C8Y_PASSWORD: "mypassword",
         C8Y_TOKEN: testToken,
+        C8Y_TENANT: "t1234567",
         admin_username: "admin",
         admin_password: "password",
         admin_token: testToken,
@@ -237,11 +238,12 @@ describe("auth", () => {
           token: testToken,
           tenant: "t1234567",
         });
-        expect(Object.keys(props.env)).to.have.length(7);
+        expect(Object.keys(props.env)).to.have.length(8);
         expect(props.env).to.deep.eq({
           C8Y_USERNAME: "myusername",
           C8Y_PASSWORD: "mypassword",
           C8Y_TOKEN: testToken,
+          C8Y_TENANT: "t1234567",
           admin_token: testToken,
           admin_username: "admin",
           admin_password: "password",
@@ -288,6 +290,75 @@ describe("auth", () => {
           expect(result?.tenant).to.eq("t1234567");
           expect(result?.userAlias).to.eq("mytoken");
         });
+    });
+
+    it("should use tenant from userAlias_tenant env variable", () => {
+      stubEnv({
+        admin_username: "admin",
+        admin_password: "password",
+        admin_tenant: "t9876543",
+      });
+      cy.getAuth("admin").then((result) => {
+        expect(result?.user).to.eq("admin");
+        expect(result?.password).to.eq("password");
+        expect(result?.tenant).to.eq("t9876543");
+        expect(result?.userAlias).to.eq("admin");
+      });
+    });
+
+    it("should fallback to C8Y_TENANT when userAlias_tenant is not set", () => {
+      stubEnv({
+        admin_username: "admin",
+        admin_password: "password",
+        // admin_tenant NOT set - should fallback to C8Y_TENANT
+      });
+      cy.getAuth("admin").then((result) => {
+        expect(result?.user).to.eq("admin");
+        expect(result?.password).to.eq("password");
+        expect(result?.tenant).to.eq("t1234567"); // From C8Y_TENANT set in beforeEach
+        expect(result?.userAlias).to.eq("admin");
+      });
+    });
+
+    it("should prefer explicit tenant option over userAlias_tenant", () => {
+      stubEnv({
+        mytenant_username: "user",
+        mytenant_password: "pass",
+        mytenant_tenant: "t9876543",
+      });
+      cy.wrap({ userAlias: "mytenant", tenant: "texplicit" })
+        .getAuth()
+        .then((result) => {
+          expect(result?.user).to.eq("user");
+          expect(result?.password).to.eq("pass");
+          expect(result?.tenant).to.eq("texplicit");
+          expect(result?.userAlias).to.eq("mytenant");
+        });
+    });
+
+    it("should support multiple users with different tenants", () => {
+      stubEnv({
+        user1_username: "user1",
+        user1_password: "pass1",
+        user1_tenant: "ttenant1",
+        user2_username: "user2",
+        user2_password: "pass2",
+        user2_tenant: "ttenant2",
+      });
+
+      // Test user1
+      cy.getAuth("user1").then((result) => {
+        expect(result?.user).to.eq("user1");
+        expect(result?.password).to.eq("pass1");
+        expect(result?.tenant).to.eq("ttenant1");
+      });
+
+      // Test user2
+      cy.getAuth("user2").then((result) => {
+        expect(result?.user).to.eq("user2");
+        expect(result?.password).to.eq("pass2");
+        expect(result?.tenant).to.eq("ttenant2");
+      });
     });
   });
 
@@ -414,6 +485,7 @@ describe("auth", () => {
       stubEnv({
         C8Y_USERNAME: "myusername",
         C8Y_PASSWORD: "mypassword",
+        C8Y_TENANT: "t1234567",
         admin_username: "admin",
         admin_password: "password",
         abc: "def",
@@ -436,6 +508,7 @@ describe("auth", () => {
         expect(props.env).to.deep.eq({
           C8Y_USERNAME: "myusername",
           C8Y_PASSWORD: "mypassword",
+          C8Y_TENANT: "t1234567",
           admin_username: "admin",
           admin_password: "password",
           // from environment / defined in beforeEach

--- a/test/cypress/e2e/runner.cy.ts
+++ b/test/cypress/e2e/runner.cy.ts
@@ -3,6 +3,7 @@ import {
   C8yDefaultPact,
   C8yDefaultPactRecord,
   getOptionsFromEnvironment,
+  getAuthOptionsFromBasicAuthHeader,
 } from "cumulocity-cypress/c8ypact";
 import { basicAuthorization, stubEnv } from "cypress/support/testutils";
 
@@ -595,6 +596,149 @@ describe("pact runner", () => {
         "tenantRequest"
       );
       runner.runTest(pact); // No auth type, no user
+    });
+
+    it("should fallback to C8Y_TENANT when userAlias_tenant is not specified", () => {
+      stubEnv({
+        parentadmin_username: "parentadmin",
+        parentadmin_password: "parentpass",
+        // parentadmin_tenant NOT specified - should fallback to C8Y_TENANT
+        C8Y_TENANT: "ttenant",
+        C8Y_USERNAME: "fallbackuser",
+        C8Y_PASSWORD: "fallbackpass",
+      });
+
+      const pact = new C8yDefaultPact(
+        [
+          new C8yDefaultPactRecord(
+            {
+              method: "GET",
+              url: `${Cypress.config().baseUrl}/tenant/currentTenant`,
+            },
+            responseMock,
+            {},
+            { userAlias: "parentadmin" }
+          ),
+          new C8yDefaultPactRecord(
+            {
+              method: "GET",
+              url: `${Cypress.config().baseUrl}/tenant/currentTenant`,
+            },
+            responseMock,
+            {}
+            // No userAlias - should use global auth
+          ),
+        ],
+        {
+          id: "fallback-tenant-test",
+          title: ["Fallback Tenant Test"],
+          baseUrl: Cypress.config().baseUrl!,
+        },
+        "fallback-tenant-test"
+      );
+
+      cy.intercept("GET", "**/tenant/currentTenant*", responseMock).as(
+        "tenantRequest"
+      );
+
+      runner.runTest(pact);
+
+      cy.get("@tenantRequest.all").should("have.length", 2);
+      // both should use C8Y_TENANT since no userAlias_tenant is provided
+      cy.get("@tenantRequest.all").then((calls: any) => {
+        expect(calls[0].request.headers).to.have.property(
+          "authorization",
+          basicAuthorization("parentadmin", "parentpass", "ttenant")
+        );
+        expect(calls[1].request.headers).to.have.property(
+          "authorization",
+          basicAuthorization("fallbackuser", "fallbackpass", "ttenant")
+        );
+      });
+    });
+
+    it("should handle different tenant queries in same pact runner test", () => {
+      stubEnv({
+        parent_username: "parentadmin",
+        parent_password: "parentpass",
+        parent_tenant: "t0000001",
+        child_username: "childadmin",
+        child_password: "childpass",
+        child_tenant: "t0000001-child1",
+      });
+
+      const responseMockParent = { status: 200, body: { name: "Parent" } };
+      const responseMockChild = { status: 200, body: { name: "Child" } };
+
+      const pact = new C8yDefaultPact(
+        [
+          new C8yDefaultPactRecord(
+            {
+              method: "GET",
+              url: `${Cypress.config().baseUrl}/tenant/currentTenant`,
+            },
+            responseMockParent,
+            {},
+            { userAlias: "parent" }
+          ),
+          new C8yDefaultPactRecord(
+            {
+              method: "GET",
+              url: `${Cypress.config().baseUrl}/tenant/currentTenant`,
+            },
+            responseMockChild,
+            {},
+            { userAlias: "child" }
+          ),
+          new C8yDefaultPactRecord(
+            {
+              method: "GET",
+              url: `${Cypress.config().baseUrl}/tenant/currentTenant`,
+            },
+            responseMockParent,
+            {},
+            { userAlias: "parent" }
+          ),
+        ],
+        {
+          id: "parent-child-test",
+          title: ["Parent Child Tenant Test"],
+          baseUrl: Cypress.config().baseUrl!,
+        },
+        "parent-child-test"
+      );
+
+      cy.intercept("GET", "**/tenant/currentTenant*", (req) => {
+        // Route to appropriate response based on auth header
+        const authHeader: string = req.headers.authorization as string || "";
+        const auth = getAuthOptionsFromBasicAuthHeader(authHeader);
+        if (auth?.user.includes("t0000001-child1/")) {
+          req.reply(responseMockChild);
+        } else {
+          req.reply(responseMockParent);
+        }
+      }).as("tenantRequest");
+
+      runner.runTest(pact);
+
+      cy.get("@tenantRequest.all").should("have.length", 3);
+      cy.get("@tenantRequest.all").then((calls: any) => {
+        // First request - parent
+        expect(calls[0].request.headers).to.have.property(
+          "authorization",
+          basicAuthorization("parentadmin", "parentpass", "t0000001")
+        );
+        // Second request - child
+        expect(calls[1].request.headers).to.have.property(
+          "authorization",
+          basicAuthorization("childadmin", "childpass", "t0000001-child1")
+        );
+        // Third request - parent again
+        expect(calls[2].request.headers).to.have.property(
+          "authorization",
+          basicAuthorization("parentadmin", "parentpass", "t0000001")
+        );
+      });
     });
   });
 


### PR DESCRIPTION
For an auth user alias, now the tenant can be configured that overrides C8Y_TENANT env variable for the user configured by the alias. Set the environment variable `<useralias>_tenant` along with `<useralias>_username` and `<useralias>_password`. The configured tenant will be used for authentication of this user, however, for JWT token  based authentication, the tenant from the token will have precendence. 